### PR TITLE
add '+' to pos and 0 in bubble chart

### DIFF
--- a/py/visualize.py
+++ b/py/visualize.py
@@ -514,6 +514,7 @@ def bubble_chart(responses, poll_ids=None, question_ids=None, xtab1_val="-"):
         xaxis=dict(
             title=None,  # date self-explanatory
         ),
+        yaxis_tickformat = '+.0',
         legend_title_text=None,  # country self-explanatory
         autosize=True,
         # define hoverlabel characteristics


### PR DESCRIPTION
don't think the d3 format lets you leave 0 without a sign, so we're limited to
```
+1
+0
-1
```